### PR TITLE
Don't call pinecone with short message

### DIFF
--- a/src/app/services/ai-wine.service.ts
+++ b/src/app/services/ai-wine.service.ts
@@ -37,7 +37,7 @@ export class AiWineService implements WineServiceInterface {
   async invokeChat(userMessage: string): Promise<string> {
     let wineContext = undefined;
 
-    if (this.configService.isBurgundyFocused()) {
+    if (this.configService.isBurgundyFocused() && userMessage.trim().length > 10) {
       wineContext = await this.pineconeService.getContextForQuery(userMessage);
     }
 


### PR DESCRIPTION
This PR addresses issue #78. It won't call pinecone for short messages.